### PR TITLE
feat(wasm): Add support for builtins + uprev to Wasmtime 7

### DIFF
--- a/crates/opa/Cargo.toml
+++ b/crates/opa/Cargo.toml
@@ -15,6 +15,7 @@ bytes = "1.1.0"
 serde = { version = "1.0.133", features = ["derive"] }
 serde_json = "1.0.74"
 thiserror = "1.0.30"
+tracing = "0.1"
 
 flate2 = { version = "1.0.22", optional = true }
 tar = { version = "0.4.38", optional = true }

--- a/crates/opa/Cargo.toml
+++ b/crates/opa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opa"
-version = "0.9.0"
+version = "0.10.0-dev"
 edition = "2021"
 description = "Unofficial SDK library for Open Policy Agent"
 repository = "https://github.com/tamasfe/opa-rs"
@@ -23,7 +23,7 @@ reqwest = { version = "0.11.8", features = ["json"], optional = true }
 url = { version = "2.2.2", optional = true }
 uuid = { version = ">=0.8.2", features = ["serde"], optional = true }
 
-wasmtime = { version = "3.0.0", optional = true, default-features = false }
+wasmtime = { version = "7.0", optional = true, default-features = false }
 
 which = { version = "4.2.4", optional = true }
 walkdir = { version = "2.3.2", optional = true }

--- a/crates/opa/src/build/mod.rs
+++ b/crates/opa/src/build/mod.rs
@@ -178,13 +178,19 @@ impl WasmPolicyBuilder {
         let output_file_name = self.name;
         let output_file_path = out_dir.join(&format!("{output_file_name}.tar.gz"));
 
-        opa_cmd.args([
-            "build",
-            "-t",
-            "wasm",
-            "-o",
-            output_file_path.to_str().unwrap(),
+        let mut args = Vec::<String>::from([
+            "build".to_string(),
+            "-t".to_string(),
+            "wasm".to_string(),
+            "-o".to_string(),
+            output_file_path.to_str().unwrap().to_string(),
         ]);
+        let capabilities = env::var("OPA_CAPABILITIES");
+        if let Ok(caps) = capabilities {
+            println!("cargo:rustc-env=OPA_CAPABILITIES={caps}");
+            args.append(&mut Vec::from(["--capabilities".to_string(), caps.clone()]));
+        }
+        opa_cmd.args(&args);
 
         if let Some(opt) = self.opt_level {
             opa_cmd.arg("-O");


### PR DESCRIPTION
This adds support for providing a map of builtin function handlers to a WASM policy module.

I’ve also added support for setting the `--capabilities` flag in the build script with the `OPA_CAPABILITIES` environment variable. I normally wouldn’t have included it with this PR however I mistakenly thought it was required to enable builtins in OPA WASM 🙃

Finally, I’ve uprevved to Wasmtime 7 as there is a CVE in `3.0.0` and I happen to use 7 in my own project :)

Usage example:

```rust
let mut builtins: HashMap<String, opa::wasm::BuiltinHandler> = Default::default();
builtins.insert(“io.jwt.decode_verify”.to_string(), Box::new(|args| {
    todo!()
    0u32
}));

Opa::new()
    .with_builtins(builtins)
    .build_from_bundle(&bundle)
    .unwrap(); 
```